### PR TITLE
Clarify subscription status entitlement documentation

### DIFF
--- a/content/docs/dashboard/products.mdx
+++ b/content/docs/dashboard/products.mdx
@@ -47,16 +47,13 @@ localized.
 Entitlements represent the amount of access or features users are entitled to. They can be used to offer different tiers of service, or just represent a single "active" subscription if your app only has one level of service (i.e. "Pro" unlocks everything). All products are granted a default entitlement.
 
 <Warning>
-  Subscription status is determined by entitlements. If a user has no active
-  entitlements (for example, if your products are not attached to any
-  entitlement), their subscription status will be <b>Inactive</b>. Ensure each
-  subscription product is linked to at least one entitlement. If you only have
-  one tier, using the default entitlement is sufficient.
+  **Subscription status is determined by entitlements.**
 
-  See the SDK reference for details: [iOS `subscriptionStatus`](/ios/sdk-reference/subscriptionStatus), [Android `subscriptionStatus`](/android/sdk-reference/subscriptionStatus).
+  If a product has no entitlements then when a user purchases it their subscription status will be **Inactive**.
+  Ensure each subscription product is linked to at least one entitlement.
 </Warning>
 
-**If you don't have multiple tiers of service, you can use the default entitlement — you don't need to create any additional entitlements.**
+If you don't have multiple tiers of service, you can use only the default `pro` entitlement — you don't need to create any additional entitlements.
 
 To add an entitlement, **click** on the **Entitlements** tab within the products page. Then click **Add Entitlement**:
 


### PR DESCRIPTION
Clarify the entitlements section to emphasize its role in subscription status and rephrase a confusing sentence.

The original text was unclear about the necessity of entitlements for subscription status and the meaning of "additional" entitlements, leading to potential user confusion. This PR addresses that feedback directly by adding a warning about subscription status being driven by entitlements and rephrasing the sentence for clarity.

---
Linear Issue: [SW-3956](https://linear.app/superwall/issue/SW-3956/docs-clarify-entitlements-section-for-subscription-status)

<a href="https://cursor.com/background-agent?bcId=bc-05015ba1-4634-4482-9e72-71e8cd445b00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-05015ba1-4634-4482-9e72-71e8cd445b00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

