### PR TITLE
Update dashboard docs with team roles

### DIFF
--- a/content/docs/dashboard/dashboard-settings/overview-settings-team.mdx
+++ b/content/docs/dashboard/dashboard-settings/overview-settings-team.mdx
@@ -20,6 +20,46 @@ From there, fill out the details (name and email address) and **click** the **In
 
 Once the user accepts the invite, they'll show up in your Team section. You can add or remove team members at anytime. To remove a team member, **click** the **trashcan** icon under **Actions**.
 
+### Team roles
+
+Only **Owners** or **Admins** can change team member roles.
+
+#### Owner — Full control
+
+- Can perform all actions on the team/organization
+- Can invite/remove team members
+- Can assign or change any team member's role including other Owners
+- Can modify billing and organization settings
+- Access to all features including sensitive data (webhooks, API keys)
+- Maximum privileges
+
+#### Admin — Full access, limited team management
+
+- Can perform most administrative actions
+- Can invite/remove team members
+- Cannot assign or change Owner roles (can only assign Admin, Editor, or Reader)
+- Access to sensitive features like webhook destinations
+- Full create/update/delete permissions on paywalls, campaigns, products, etc.
+
+#### Editor — Can create and modify content
+
+- Can read, create, and update:
+  - Paywalls and paywall triggers
+  - Campaigns and A/B tests
+  - Products
+  - Notifications
+  - Projects
+- Can view applications and organizations
+- Cannot delete applications
+- Cannot access team management (invite/remove members)
+- Cannot access sensitive settings like webhooks or billing
+
+#### Reader — View-only access
+
+- Can view/read all resources (paywalls, campaigns, analytics, etc.)
+- Cannot create, update, or delete anything
+- Useful for stakeholders who need visibility but shouldn't make changes
+
 ### Renaming your team
 
 To rename your team, enter in a new value name under the **Team Name** section, and **click** the **Save** button:


### PR DESCRIPTION
Add a new 'Team roles' section to the dashboard settings documentation to outline each role's permissions.

---
Linear Issue: [SW-4059](https://linear.app/superwall/issue/SW-4059/docs-dashboard-team-roles)

<a href="https://cursor.com/background-agent?bcId=bc-bd14626d-4587-438d-a101-28c530e667c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bd14626d-4587-438d-a101-28c530e667c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Documents team roles and permissions in the dashboard settings, including role change restrictions.
> 
> - **Docs**:
>   - Add a new *Team roles* section in `content/docs/dashboard/dashboard-settings/overview-settings-team.mdx` detailing permissions for `Owner`, `Admin`, `Editor`, and `Reader` roles and noting that only `Owners` or `Admins` can change member roles.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aa6e5403b54952ec230112fdd0ac140c30dbf923. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->