### PR TITLE
Clarify uuid requirement for app account token

### DIFF
--- a/content/docs/ios/sdk-reference/identify.mdx
+++ b/content/docs/ios/sdk-reference/identify.mdx
@@ -27,9 +27,9 @@ public func identify(
 </ParamTable>
 
 <Warning>
-  iOS only: `appAccountToken` must be a UUID. If the `userId` you pass to `identify` is not a valid UUID string, StoreKit will not accept it for `appAccountToken` and the SDK will fall back to the anonymous alias UUID. This can cause the identifier in App Store Server Notifications to differ from the `userId` you passed.
-
-  For consistency, always use a v4 UUID for `userId` on iOS. See Apple's docs: [appAccountToken](https://developer.apple.com/documentation/appstoreserverapi/appaccounttoken).
+  `appAccountToken` must be a UUID to be accepted by StoreKit.
+  
+  If the `userId` you pass to `identify` is not a valid UUID string, StoreKit will not accept it for `appAccountToken` and the SDK will fall back to the anonymous alias UUID. This can cause the identifier in App Store Server Notifications to differ from the `userId` you passed. See Apple's docs: [appAccountToken](https://developer.apple.com/documentation/appstoreserverapi/appaccounttoken).
 </Warning>
 
 ## Returns / State

--- a/content/shared/user-management/identity-management.mdx
+++ b/content/shared/user-management/identity-management.mdx
@@ -113,16 +113,31 @@ On iOS, Superwall always supplies an [`appAccountToken`](https://developer.apple
 |----------|----------------------------------|
 | You’ve called `Superwall.shared.identify(userId:)` | The exact `userId` you passed |
 | You *haven’t* called `identify` yet | The UUID automatically generated for the anonymous user (the **alias ID**), **without** the `$SuperwallAlias:` prefix |
-
 | You passed a non‑UUID `userId` to `identify` | StoreKit rejects it; Superwall falls back to the alias UUID |
 
 Because the SDK falls back to the alias UUID, purchase notifications sent to your server always include a stable, unique identifier—even before the user signs in.
 
+:::ios
 <Warning>
-  On iOS, `appAccountToken` must be a UUID. If the `userId` you pass to `identify` is not a valid UUID string, StoreKit will not accept it for `appAccountToken` and transactions will instead contain the anonymous alias UUID. This can make the identifier you see in App Store Server Notifications differ from the `userId` you passed to `identify`.
-
-  To avoid confusion, always use a v4 UUID for your `userId` on iOS.
+  `appAccountToken` must be a UUID to be accepted by StoreKit.
+  
+  If the `userId` you pass to `identify` is not a valid UUID string, StoreKit will not accept it for `appAccountToken` and the SDK will fall back to the anonymous alias UUID. This can cause the identifier in App Store Server Notifications to differ from the `userId` you passed. See Apple's docs: [appAccountToken](https://developer.apple.com/documentation/appstoreserverapi/appaccounttoken).
 </Warning>
+:::
+:::flutter
+<Warning>
+  On iOS, `appAccountToken` must be a UUID to be accepted by StoreKit.
+  
+  If the `userId` you pass to `identify` is not a valid UUID string, StoreKit will not accept it for `appAccountToken` and the SDK will fall back to the anonymous alias UUID. This can cause the identifier in App Store Server Notifications to differ from the `userId` you passed. See Apple's docs: [appAccountToken](https://developer.apple.com/documentation/appstoreserverapi/appaccounttoken).
+</Warning>
+:::
+:::expo
+<Warning>
+  On iOS, `appAccountToken` must be a UUID to be accepted by StoreKit.
+  
+  If the `userId` you pass to `identify` is not a valid UUID string, StoreKit will not accept it for `appAccountToken` and the SDK will fall back to the anonymous alias UUID. This can cause the identifier in App Store Server Notifications to differ from the `userId` you passed. See Apple's docs: [appAccountToken](https://developer.apple.com/documentation/appstoreserverapi/appaccounttoken).
+</Warning>
+:::
 
 ```swift
 // Generate and use a UUID user ID in Swift


### PR DESCRIPTION
Clarify that the `userId` must be a valid UUID on iOS for `appAccountToken` to ensure consistency with Apple's requirements and prevent identifier mismatches in purchase notifications.

The `appAccountToken` in App Store Server Notifications will differ from the `userId` passed to `identify` if the `userId` is not a valid UUID, as StoreKit silently rejects non-UUIDs and the SDK falls back to the anonymous alias UUID. This update explicitly warns users about this behavior and provides guidance.

---
Linear Issue: [SW-3485](https://linear.app/superwall/issue/SW-3485/docs-clarify-that-user-id-needs-to-be-valid-uuid-for-appaccounttoken)

<a href="https://cursor.com/background-agent?bcId=bc-a7b28e9b-a33c-4a9e-adc3-7c93110179aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a7b28e9b-a33c-4a9e-adc3-7c93110179aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies that `userId` must be a UUID on iOS for `appAccountToken`, documents fallback to alias UUID if not, and adds guidance and example.
> 
> - **iOS Docs**:
>   - **Warning added in** `content/docs/ios/sdk-reference/identify.mdx`: `userId` must be a UUID for `appAccountToken`; non-UUIDs are rejected and SDK falls back to the alias UUID; recommend v4 UUID.
> - **Identity Management** (`content/shared/user-management/identity-management.mdx`):
>   - **Table update**: Adds non-UUID `userId` scenario (StoreKit rejection → alias UUID fallback).
>   - **Warning block**: Explains UUID requirement and potential identifier mismatch in App Store Server Notifications.
>   - **Swift example**: Shows generating and using a UUID for `identify`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d4d89bd25b9575778676ad93fd5bc17e1e65d403. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->