### PR TITLE
Update web checkout revenuecat redemption example

### DIFF
--- a/content/docs/android/guides/web-checkout/using-revenuecat.mdx
+++ b/content/docs/android/guides/web-checkout/using-revenuecat.mdx
@@ -30,9 +30,10 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
-import okhttp3.Request
-import okhttp3.RequestBody.Companion.toRequestBody
-import org.json.JSONObject
+  import okhttp3.Request
+  import okhttp3.RequestBody.Companion.toRequestBody
+  import org.json.JSONObject
+  import java.io.IOException
 
 class SWDelegate : SuperwallDelegate {
   private val client = OkHttpClient()
@@ -60,8 +61,8 @@ class SWDelegate : SuperwallDelegate {
 
     // In the background using coroutines...
     coroutineScope.launch {
-      // For each subscription id, link it to the user in RevenueCat
-      stripeSubscriptionIds.forEach { stripeSubscriptionId ->
+        // For each subscription id, link it to the user in RevenueCat
+        stripeSubscriptionIds.forEach { stripeSubscriptionId ->
         try {
           val json = JSONObject().apply {
             put("app_user_id", appUserId)
@@ -80,14 +81,15 @@ class SWDelegate : SuperwallDelegate {
             .addHeader("Authorization", "Bearer $revenueCatStripePublicAPIKey")
             .build()
 
-          val response = client.newCall(request).execute()
-          val responseBody = response.body?.string()
-          
-          if (response.isSuccessful) {
-            Log.d("Superwall", "[!] Success: linked $stripeSubscriptionId to user $appUserId: $responseBody")
-          } else {
-            Log.e("Superwall", "[!] Error: unable to link $stripeSubscriptionId to user $appUserId. Response: $responseBody")
-          }
+            client.newCall(request).execute().use { response ->
+              val responseBody = response.body?.string().orEmpty()
+
+              if (!response.isSuccessful) {
+                throw IOException("RevenueCat responded with ${response.code}: $responseBody")
+              }
+
+              Log.d("Superwall", "[!] Success: linked $stripeSubscriptionId to user $appUserId: $responseBody")
+            }
         } catch (e: Exception) {
           Log.e("Superwall", "[!] Error: unable to link $stripeSubscriptionId to user $appUserId", e)
         }
@@ -119,6 +121,11 @@ class SWDelegate : SuperwallDelegate {
   }
 }
 ```
+
+<Note>
+  The example surfaces non-200 responses and network exceptions so you can add retries, user messaging,
+  or monitoring. Customize the error handling to fit your production logging and UX.
+</Note>
 
 <Warning>
   If you call `logIn` from RevenueCat's SDK, then you need to call the logic you've implemented

--- a/content/docs/expo/guides/web-checkout/using-revenuecat.mdx
+++ b/content/docs/expo/guides/web-checkout/using-revenuecat.mdx
@@ -48,33 +48,36 @@ export class SWDelegate extends SuperwallDelegate {
 
     // In the background, process all subscription IDs
     await Promise.all(
-      stripeSubscriptionIds.map(async (stripeSubscriptionId) => {
-        try {
-          const response = await fetch('https://api.revenuecat.com/v1/receipts', {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              'Accept': 'application/json',
-              'X-Platform': 'stripe',
-              'Authorization': `Bearer ${revenueCatStripePublicAPIKey}`,
-            },
-            body: JSON.stringify({
-              app_user_id: appUserId,
-              fetch_token: stripeSubscriptionId,
-            }),
-          });
+        stripeSubscriptionIds.map(async (stripeSubscriptionId) => {
+          try {
+            const response = await fetch('https://api.revenuecat.com/v1/receipts', {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                'Accept': 'application/json',
+                'X-Platform': 'stripe',
+                'Authorization': `Bearer ${revenueCatStripePublicAPIKey}`,
+              },
+              body: JSON.stringify({
+                app_user_id: appUserId,
+                fetch_token: stripeSubscriptionId,
+              }),
+            });
 
-          const data = await response.json();
-          
-          if (response.ok) {
+            const responseText = await response.text();
+
+            if (!response.ok) {
+              throw new Error(
+                `RevenueCat responded with ${response.status}: ${responseText || 'No body'}`
+              );
+            }
+
+            const data = responseText ? JSON.parse(responseText) : {};
             console.log(`[!] Success: linked ${stripeSubscriptionId} to user ${appUserId}`, data);
-          } else {
-            console.error(`[!] Error: unable to link ${stripeSubscriptionId} to user ${appUserId}. Response:`, data);
+          } catch (error) {
+            console.error(`[!] Error: unable to link ${stripeSubscriptionId} to user ${appUserId}`, error);
           }
-        } catch (error) {
-          console.error(`[!] Error: unable to link ${stripeSubscriptionId} to user ${appUserId}`, error);
-        }
-      })
+        })
     );
 
     /// After all network calls complete, invalidate the cache
@@ -99,6 +102,11 @@ export class SWDelegate extends SuperwallDelegate {
   }
 }
 ```
+
+<Note>
+  The example explicitly checks HTTP status codes and throws on failures so you can plug in retries,
+  alerting, or user messaging. Tailor the error handling to your networking stack.
+</Note>
 
 <Warning>
   If you call `logIn` from RevenueCat's SDK, then you need to call the logic you've implemented

--- a/content/docs/flutter/guides/web-checkout/using-revenuecat.mdx
+++ b/content/docs/flutter/guides/web-checkout/using-revenuecat.mdx
@@ -50,31 +50,33 @@ class MySuperwallDelegate extends SuperwallDelegate {
 
     // In the background, send requests to RevenueCat
     for (final stripeSubscriptionId in stripeSubscriptionIds) {
-      try {
-        final url = Uri.parse('https://api.revenuecat.com/v1/receipts');
-        final response = await http.post(
-          url,
-          headers: {
-            'Content-Type': 'application/json',
-            'Accept': 'application/json',
-            'X-Platform': 'stripe',
-            'Authorization': 'Bearer $revenueCatStripePublicAPIKey',
-          },
-          body: jsonEncode({
-            'app_user_id': appUserId,
-            'fetch_token': stripeSubscriptionId,
-          }),
-        );
+        try {
+          final url = Uri.parse('https://api.revenuecat.com/v1/receipts');
+          final response = await http.post(
+            url,
+            headers: {
+              'Content-Type': 'application/json',
+              'Accept': 'application/json',
+              'X-Platform': 'stripe',
+              'Authorization': 'Bearer $revenueCatStripePublicAPIKey',
+            },
+            body: jsonEncode({
+              'app_user_id': appUserId,
+              'fetch_token': stripeSubscriptionId,
+            }),
+          );
 
-        if (response.statusCode == 200) {
+          if (response.statusCode != 200) {
+            throw Exception(
+              'RevenueCat responded with ${response.statusCode}: ${response.body}',
+            );
+          }
+
           final json = jsonDecode(response.body);
           print('[!] Success: linked $stripeSubscriptionId to user $appUserId: $json');
-        } else {
-          print('[!] Error: unable to link $stripeSubscriptionId to user $appUserId. Status: ${response.statusCode}');
+        } catch (error) {
+          print('[!] Error: unable to link $stripeSubscriptionId to user $appUserId: $error');
         }
-      } catch (error) {
-        print('[!] Error: unable to link $stripeSubscriptionId to user $appUserId: $error');
-      }
     }
 
     // After all network calls complete, invalidate the cache
@@ -99,6 +101,11 @@ class MySuperwallDelegate extends SuperwallDelegate {
   }
 }
 ```
+
+<Note>
+  The example throws when RevenueCat responds with an error so you can add retries, alerts, or custom
+  UI. Adapt the error-handling strategy to your networking and logging requirements.
+</Note>
 
 Set up the delegate when configuring Superwall:
 
@@ -198,11 +205,13 @@ class MySuperwallDelegate extends SuperwallDelegate {
       }),
     );
 
-    if (response.statusCode == 200) {
-      print('[!] Successfully linked $stripeSubscriptionId to $appUserId');
-    } else {
-      throw Exception('Failed to link subscription: ${response.statusCode}');
+    if (response.statusCode != 200) {
+      throw Exception(
+        'RevenueCat responded with ${response.statusCode}: ${response.body}',
+      );
     }
+
+    print('[!] Successfully linked $stripeSubscriptionId to $appUserId');
   }
 }
 ```

--- a/content/shared/web-checkout/using-revenuecat.mdx
+++ b/content/shared/web-checkout/using-revenuecat.mdx
@@ -42,7 +42,7 @@ final class Delegate: SuperwallDelegate {
     let revenueCatStripePublicAPIKey = "strp....." // replace with your RevenueCat Stripe Public API Key
     let appUserId = Purchases.shared.appUserID
 
-    // In the background...
+      // In the background...
     Task.detached {
       await withTaskGroup(of: Void.self) { group in
         // For each subscription id, link it to the user in RevenueCat
@@ -55,18 +55,31 @@ final class Delegate: SuperwallDelegate {
             request.setValue("stripe", forHTTPHeaderField: "X-Platform")
             request.setValue("Bearer \(revenueCatStripePublicAPIKey)", forHTTPHeaderField: "Authorization")
 
-            do {
-              request.httpBody = try JSONEncoder().encode([
-                "app_user_id": appUserId,
-                "fetch_token": stripeSubscriptionId
-              ])
+              do {
+                request.httpBody = try JSONEncoder().encode([
+                  "app_user_id": appUserId,
+                  "fetch_token": stripeSubscriptionId
+                ])
 
-              let (data, _) = try await URLSession.shared.data(for: request)
-              let json = try JSONSerialization.jsonObject(with: data, options: [])
-              print("[!] Success: linked \(stripeSubscriptionId) to user \(appUserId)", json)
-            } catch {
-              print("[!] Error: unable to link \(stripeSubscriptionId) to user \(appUserId)", error)
-            }
+                let (data, response) = try await URLSession.shared.data(for: request)
+
+                guard let httpResponse = response as? HTTPURLResponse else {
+                  print("[!] Error: Received an invalid response for \(stripeSubscriptionId)")
+                  return
+                }
+
+                guard (200..<300).contains(httpResponse.statusCode) else {
+                  let body = String(data: data, encoding: .utf8) ?? ""
+                  print("[!] Error: RevenueCat responded with \(httpResponse.statusCode) for \(stripeSubscriptionId). Body: \(body)")
+                  return
+                }
+
+                let json = try JSONSerialization.jsonObject(with: data, options: [])
+                print("[!] Success: linked \(stripeSubscriptionId) to user \(appUserId)", json)
+              } catch {
+                // Surface network errors so you can retry or notify the user.
+                print("[!] Error: unable to link \(stripeSubscriptionId) to user \(appUserId)", error)
+              }
           }
         }
       }
@@ -92,6 +105,11 @@ final class Delegate: SuperwallDelegate {
   }
 }
 ```
+
+<Note>
+  The snippet logs HTTP failures and propagates network errors so you can build retries, show UI,
+  or report the issue. Be sure to adapt the error handling to match your monitoring and UX needs.
+</Note>
 
 <Warning>
   If you call `logIn` from RevenueCat's SDK, then you need to call the logic you've implemented


### PR DESCRIPTION
Update web checkout RevenueCat redemption examples to recommend error handling for network calls.

---
Linear Issue: [SW-4367](https://linear.app/superwall/issue/SW-4367/docs-update-web-checkout-revenuecat-redemption-example-code-to)

<a href="https://cursor.com/background-agent?bcId=bc-2354288c-a620-4a16-a3c0-c7f225f26f06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2354288c-a620-4a16-a3c0-c7f225f26f06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Tightens RevenueCat redemption examples across Android, Expo, Flutter, and Swift to check HTTP status codes, surface network errors, and guide retries/UX with added notes.
> 
> - **Docs: Web Checkout + RevenueCat**
>   - **Android (Kotlin)**: Use `execute().use {}`; check `response.isSuccessful`; throw `IOException` on non-2xx; log structured success/error; minor import fixes.
>   - **Expo (TypeScript/React Native)**: Read `response.text()`; throw on non-OK with status/body; parse JSON conditionally; improved error logging within `Promise.all`.
>   - **Flutter (Dart)**: Throw on non-200 with status/body; structured success/error logs; added cleaner async/await alternative with helper method and `Future.wait`.
>   - **iOS (Swift, shared)**: Validate `HTTPURLResponse`; guard 2xx; log non-2xx with body; improved error surfacing within `Task`/`withTaskGroup`.
>   - **Notes**: Added guidance emphasizing explicit error handling to enable retries, monitoring, and user messaging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 36434fd10b42e841db351d722a9918f950fde52c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->