### PR TITLE
Update SDK documentation for Android

### DIFF
--- a/content/docs/android/sdk-reference/SuperwallOptions.mdx
+++ b/content/docs/android/sdk-reference/SuperwallOptions.mdx
@@ -8,19 +8,25 @@ Only modify `networkEnvironment` if explicitly instructed by the Superwall team.
 </Warning>
 
 <Tip>
-Use different `SuperwallOptions` configurations for debug and release builds to optimize logging and behavior for each environment.
+Use different `SuperwallOptions` configurations for debug and release builds to optimize logging, purchasing behavior, and Google Play settings for each environment.
 </Tip>
 
 ## Purpose
-Configures various aspects of Superwall behavior including paywall presentation, networking, and logging.
+Configures paywall presentation, logging, Google Play purchase behavior, and other global SDK settings. Pass an instance in to [`Superwall.configure`](/android/sdk-reference/configure).
 
 ## Signature
 ```kotlin
 class SuperwallOptions {
     var paywalls: PaywallOptions = PaywallOptions()
-    var networkEnvironment: NetworkEnvironment = NetworkEnvironment.RELEASE
-    var logging: LoggingOptions = LoggingOptions()
+    var shouldObservePurchases: Boolean = false
+    var networkEnvironment: NetworkEnvironment = NetworkEnvironment.Release()
+    var isExternalDataCollectionEnabled: Boolean = true
     var localeIdentifier: String? = null
+    var isGameControllerEnabled: Boolean = false
+    var passIdentifiersToPlayStore: Boolean = false
+    var enableExperimentalDeviceVariables: Boolean = false
+    var logging: Logging = Logging()
+    var useMockReviews: Boolean = false
 }
 ```
 
@@ -28,9 +34,15 @@ class SuperwallOptions {
 // Java
 public class SuperwallOptions {
     public PaywallOptions paywalls = new PaywallOptions();
-    public NetworkEnvironment networkEnvironment = NetworkEnvironment.RELEASE;
-    public LoggingOptions logging = new LoggingOptions();
-    public String localeIdentifier = null;
+    public boolean shouldObservePurchases = false;
+    public NetworkEnvironment networkEnvironment = new NetworkEnvironment.Release();
+    public boolean isExternalDataCollectionEnabled = true;
+    public @Nullable String localeIdentifier = null;
+    public boolean isGameControllerEnabled = false;
+    public boolean passIdentifiersToPlayStore = false;
+    public boolean enableExperimentalDeviceVariables = false;
+    public Logging logging = new Logging();
+    public boolean useMockReviews = false;
 }
 ```
 
@@ -38,31 +50,32 @@ public class SuperwallOptions {
 <ParamTable>
 | Property | Type | Description |
 |----------|------|-------------|
-| `paywalls` | [`PaywallOptions`](/android/sdk-reference/PaywallOptions) | Configuration for paywall appearance and behavior. |
-| `networkEnvironment` | `NetworkEnvironment` | Network environment (`.RELEASE`, `.RELEASE_CANDIDATE`, `.DEVELOPER`, `.CUSTOM(String)`). **Use only if instructed by Superwall team.** |
-| `logging` | `LoggingOptions` | Logging configuration including level and scopes. |
-| `localeIdentifier` | `String?` | Override locale for paywall localization (e.g., "en_GB"). |
+| `paywalls` | [`PaywallOptions`](/android/sdk-reference/PaywallOptions) | Controls paywall presentation, preload, and alert behavior. |
+| `shouldObservePurchases` | `Boolean` | Set to `true` to have Superwall observe Google Play purchases you make outside the SDK. |
+| `networkEnvironment` | `NetworkEnvironment` | Overrides the API environment. **Only change if instructed by Superwall.** |
+| `isExternalDataCollectionEnabled` | `Boolean` | Allows Superwall to send non-paywall analytics events to the backend. Defaults to `true`. |
+| `localeIdentifier` | `String?` | Overrides the locale used for rule evaluation (e.g., `"en_GB"`). |
+| `isGameControllerEnabled` | `Boolean` | Forwards game controller events to paywalls. |
+| `passIdentifiersToPlayStore` | `Boolean` | When `true`, Google Play receives the raw `userId` as `obfuscatedExternalAccountId`; otherwise Superwall sends a SHA-256 hash. |
+| `enableExperimentalDeviceVariables` | `Boolean` | Enables experimental device variables (subject to change). |
+| `logging` | `Logging` | Sets log level and scopes printed to Logcat. |
+| `useMockReviews` | `Boolean` | Shows mock Google Play review dialogs for testing. |
 </ParamTable>
 
-## Returns / State
-This is a configuration object used when calling [`configure()`](/android/sdk-reference/configure).
+## How `passIdentifiersToPlayStore` affects Google Play
+Superwall always calls `BillingFlowParams.Builder.setObfuscatedAccountId(Superwall.instance.externalAccountId)` when launching a billing flow.
 
-## Usage
+- **Default (`false`)** – `externalAccountId` is a SHA-256 hash of the `userId`. Google Play displays the hashed value as `obfuscatedExternalAccountId`, and the same hash is sent back to your servers.
+- **Enabled (`true`)** – Superwall forwards the exact `appUserId` you passed to [`identify()`](/android/sdk-reference/identify). This makes it easier to correlate Google Play purchases with your users, but the value must comply with [Google's policy](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.Builder#setObfuscatedAccountId) and must not contain PII.
 
-Basic options setup:
+Configure it as part of your application startup:
+
 ```kotlin
 val options = SuperwallOptions().apply {
-    // Configure paywall behavior
-    paywalls.shouldShowPurchaseFailureAlert = false
-    
-    // Configure logging
-    logging.level = LogLevel.WARN
-    
-    // Set locale for testing
-    localeIdentifier = "en_GB"
+    passIdentifiersToPlayStore = true
+    logging.level = LogLevel.info
 }
 
-// Use with configure
 Superwall.configure(
     application = this,
     apiKey = "pk_your_api_key",

--- a/content/docs/expo/sdk-reference/hooks/useSuperwall.mdx
+++ b/content/docs/expo/sdk-reference/hooks/useSuperwall.mdx
@@ -28,6 +28,7 @@ The hook returns an object representing the Superwall store. If a `selector` fun
 
 ### Actions (Functions)
 -   `configure: (apiKey: string, options?: Record<string, any>) => Promise<void>`: Initializes the Superwall SDK with the provided API key and optional configuration options.
+    -   **Android / Google Play**: Include `{ passIdentifiersToPlayStore: true }` in the `options` object if you need the raw `appUserId` forwarded to Google Play as `obfuscatedExternalAccountId`. Otherwise the SDK sends a SHA-256 hash. This flag is ignored on iOS builds but you can guard it with `Platform.OS === "android"` if you prefer.
 -   `identify: (userId: string, options?: IdentifyOptions) => Promise<void>`: Identifies the user with the given `userId`.
     -   `IdentifyOptions`:
         -   `restorePaywallAssignments?: boolean`: If true, restores paywall assignments from a previous session.
@@ -63,5 +64,21 @@ function MyAdvancedComponent() {
   };
 
   return <Button title="Set Custom Flag" onPress={handleSetCustomAttribute} />;
+}
+```
+
+### Example: Configure with Android identifiers
+
+```tsx
+import { Platform } from "react-native"
+import Superwall from "expo-superwall/compat"
+
+async function configureSuperwall() {
+  await Superwall.configure({
+    apiKey: Platform.OS === "ios" ? IOS_KEY : ANDROID_KEY,
+    options: Platform.OS === "android"
+      ? { passIdentifiersToPlayStore: true }
+      : undefined,
+  })
 }
 ```

--- a/content/docs/flutter/sdk-reference/SuperwallOptions.mdx
+++ b/content/docs/flutter/sdk-reference/SuperwallOptions.mdx
@@ -9,12 +9,13 @@ Configures various aspects of the Superwall SDK including paywall behavior, logg
 ## Signature
 ```dart
 class SuperwallOptions {
-  final PaywallOptions paywalls;
-  final NetworkEnvironment networkEnvironment;
-  final bool isExternalDataCollectionEnabled;
-  final String? localeIdentifier;
-  final bool isGameControllerEnabled;
-  final Logging logging;
+  PaywallOptions paywalls = PaywallOptions();
+  NetworkEnvironment networkEnvironment = NetworkEnvironment.release;
+  bool isExternalDataCollectionEnabled = true;
+  String? localeIdentifier;
+  bool isGameControllerEnabled = false;
+  Logging logging = Logging();
+  bool passIdentifiersToPlayStore = false;
 }
 ```
 
@@ -23,26 +24,41 @@ class SuperwallOptions {
 | Property | Type | Description |
 |----------|------|-------------|
 | `paywalls` | [`PaywallOptions`](/flutter/sdk-reference/PaywallOptions) | Configuration for paywall presentation behavior. |
-| `networkEnvironment` | `NetworkEnvironment` | Network environment for API calls (release/staging). |
-| `isExternalDataCollectionEnabled` | `bool` | Enables external data collection for analytics. Defaults to `true`. |
+| `networkEnvironment` | `NetworkEnvironment` | Network environment for API calls (release/releaseCandidate/developer). Only change when instructed by Superwall. |
+| `isExternalDataCollectionEnabled` | `bool` | Enables external analytics collection. Defaults to `true`. |
 | `localeIdentifier` | `String?` | Override locale for paywall localization. Defaults to device locale. |
 | `isGameControllerEnabled` | `bool` | Enables game controller support. Defaults to `false`. |
 | `logging` | `Logging` | Configuration for SDK logging levels and behavior. |
+| `passIdentifiersToPlayStore` | `bool` | When `true`, Android builds send the plain `appUserId` to Google Play as `obfuscatedExternalAccountId`. Defaults to `false`. |
 </ParamTable>
+
+## Android-only: `passIdentifiersToPlayStore`
+Flutter apps can target both iOS and Android. Google Play always consumes the identifier you send through `BillingFlowParams.Builder.setObfuscatedAccountId`, which the SDK sources from `Superwall.instance.externalAccountId`.
+
+- When `passIdentifiersToPlayStore` is **`false`** (default) we SHA-256 hash your `userId` before sending it. Play Console and the Superwall backend will show the hashed value.
+- When it is **`true`**, we pass the exact `appUserId` you supplied to `Superwall.shared.identify`. This only changes behavior on Android—the flag is ignored on iOS builds.
+
+Set the option at configuration time when you specifically need the un-hashed identifier:
+
+```dart
+final options = SuperwallOptions()
+  ..passIdentifiersToPlayStore = true;
+
+await Superwall.configure(
+  apiKey,
+  options: options,
+);
+```
+
+Make sure the identifier complies with [Google's policy](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.Builder#setObfuscatedAccountId) and never contains personally identifiable information.
 
 ## Usage
 
 Basic options:
 ```dart
-final options = SuperwallOptions(
-  paywalls: PaywallOptions(
-    shouldPreload: true,
-    automaticallyDismiss: false,
-  ),
-  logging: Logging(
-    level: LogLevel.debug,
-  ),
-);
+final options = SuperwallOptions()
+  ..paywalls = PaywallOptions()
+  ..logging = (Logging()..level = LogLevel.debug);
 
 await Superwall.configure(
   'pk_your_api_key',
@@ -52,40 +68,33 @@ await Superwall.configure(
 
 Production configuration:
 ```dart
-final productionOptions = SuperwallOptions(
-  paywalls: PaywallOptions(
-    shouldPreload: true,
-    automaticallyDismiss: true,
-  ),
-  networkEnvironment: NetworkEnvironment.release,
-  isExternalDataCollectionEnabled: true,
-  logging: Logging(level: LogLevel.warn),
-);
+final productionOptions = SuperwallOptions()
+  ..paywalls = (PaywallOptions()
+    ..shouldPreload = true
+    ..automaticallyDismiss = true)
+  ..networkEnvironment = NetworkEnvironment.release
+  ..isExternalDataCollectionEnabled = true
+  ..logging = (Logging()..level = LogLevel.warn);
 ```
 
-Development configuration:
+Development configuration (with Play Store IDs on Android):
 ```dart
-final developmentOptions = SuperwallOptions(
-  paywalls: PaywallOptions(
-    shouldPreload: false, // Faster builds
-    automaticallyDismiss: false, // Manual testing
-  ),
-  networkEnvironment: NetworkEnvironment.staging,
-  logging: Logging(
-    level: LogLevel.debug,
-    scopes: [LogScope.all],
-  ),
-);
+final developmentOptions = SuperwallOptions()
+  ..paywalls = (PaywallOptions()
+    ..shouldPreload = false
+    ..automaticallyDismiss = false)
+  ..networkEnvironment = NetworkEnvironment.developer
+  ..logging = (Logging()
+    ..level = LogLevel.debug
+    ..scopes = {LogScope.all})
+  ..passIdentifiersToPlayStore = true; // Android only
 ```
 
 Custom locale:
 ```dart
-final localizedOptions = SuperwallOptions(
-  localeIdentifier: 'es_ES', // Spanish (Spain)
-  paywalls: PaywallOptions(
-    shouldPreload: true,
-  ),
-);
+final localizedOptions = SuperwallOptions()
+  ..localeIdentifier = 'es_ES' // Spanish (Spain)
+  ..paywalls = (PaywallOptions()..shouldPreload = true);
 ```
 
 ## Related

--- a/content/shared/user-management/identity-management.mdx
+++ b/content/shared/user-management/identity-management.mdx
@@ -17,13 +17,13 @@ If you use your own user management system, call `identify(userId:options:)` whe
 Calling `Superwall.shared.reset()` will reset the on-device userId to a random ID and clear the paywall assignments.
 
 :::android
-Note that for Android apps, if you want the `userId` passed to the Play Store when making purchases, you'll also need to set `passIdentifiersToPlayStore` via `SuperwallOptions`. Be aware of Google's rules that the `userId` must not contain any personally identifiable information, otherwise the purchase could [be rejected](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.Builder#setObfuscatedAccountId).
+Google Play receives the identifier you pass to `BillingFlowParams.Builder.setObfuscatedAccountId` as both the **`obfuscatedExternalAccountId`** and the `externalAccountId` we forward to your Superwall backend. By default we SHA-256 hash your `userId` before sending it. If you want the raw `appUserId` to appear in Play Console and downstream server events, set `SuperwallOptions().passIdentifiersToPlayStore = true` before configuring the SDK. Make sure the value complies with [Google's policies](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.Builder#setObfuscatedAccountId)—it must not contain personally identifiable information.
 :::
 :::flutter
-Note that for Android apps, if you want the `userId` passed to the Play Store when making purchases, you'll also need to set `passIdentifiersToPlayStore` via `SuperwallOptions`. Be aware of Google's rules that the `userId` must not contain any personally identifiable information, otherwise the purchase could [be rejected](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.Builder#setObfuscatedAccountId).
+When you ship the Flutter SDK on Android, you must explicitly set `options.passIdentifiersToPlayStore = true` (for example, `final options = SuperwallOptions()..passIdentifiersToPlayStore = true;`) if you need the un-hashed `appUserId` to flow through Google Play's **`obfuscatedExternalAccountId`** field. This flag has no effect on iOS builds. Follow [Google's rules](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.Builder#setObfuscatedAccountId) so the value is not rejected.
 :::
 :::expo
-Note that for Android apps, if you want the `userId` passed to the Play Store when making purchases, you'll also need to set `passIdentifiersToPlayStore` via `SuperwallOptions`. Be aware of Google's rules that the `userId` must not contain any personally identifiable information, otherwise the purchase could [be rejected](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.Builder#setObfuscatedAccountId).
+If your Expo app targets Android, pass `{ passIdentifiersToPlayStore: true }` inside the options object you give to `Superwall.configure`. That ensures Google Play receives the plain `appUserId` as `obfuscatedExternalAccountId`; otherwise we send a hashed value. iOS builds ignore this option. Be sure the identifier satisfies [Google's requirements](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.Builder#setObfuscatedAccountId) and never includes PII.
 :::
 
 :::ios


### PR DESCRIPTION
Document the `passIdentifiersToPlayStore` option across Android, Flutter, and Expo SDKs.

This clarifies how `appUserId` is sent to Google Play's `obfuscatedExternalAccountId` and provides accurate, Android-specific guidance for cross-platform SDKs.

---
[Slack Thread](https://superwallme.slack.com/archives/C02HBH27MLP/p1763847454050449?thread_ts=1763847454.050449&cid=C02HBH27MLP)

<a href="https://cursor.com/background-agent?bcId=bc-d0b8043a-37ee-4f82-a1f8-2e7b1e83d89f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d0b8043a-37ee-4f82-a1f8-2e7b1e83d89f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Document `passIdentifiersToPlayStore` across Android, Flutter, and Expo, update Android options signatures, and add platform-specific guidance and examples for Google Play identifiers.
> 
> - **Docs – Android `SuperwallOptions`**:
>   - Expanded API surface in signatures: add `shouldObservePurchases`, `passIdentifiersToPlayStore`, `enableExperimentalDeviceVariables`, `useMockReviews`; switch `logging` to `Logging`; update `networkEnvironment` to `NetworkEnvironment.Release()`.
>   - Updated parameter table and tip; added detailed section on how `passIdentifiersToPlayStore` affects Google Play (`obfuscatedExternalAccountId` vs hashed) with compliance note.
>   - Added Kotlin config example using `passIdentifiersToPlayStore` and `LogLevel.info`.
> - **Docs – Expo**:
>   - `useSuperwall.configure` notes Android-specific `{ passIdentifiersToPlayStore: true }` and added example guarded by `Platform.OS`.
> - **Docs – Flutter `SuperwallOptions`**:
>   - Converted to mutable fields with defaults and added `passIdentifiersToPlayStore`.
>   - Updated env values and parameter descriptions; new Android-only section explaining identifier hashing vs raw with example config; refreshed usage examples (dev/prod/localized).
> - **Shared Identity Management**:
>   - Platform-specific guidance (Android/Flutter/Expo) on identifier behavior: default SHA-256 hash vs raw when enabling `passIdentifiersToPlayStore`, plus Google policy caveats.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b0616b5d7f7e6583af427c4dcd96890f364d8c39. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->